### PR TITLE
Fix scene segment concatenation

### DIFF
--- a/render-api/app/renderer.py
+++ b/render-api/app/renderer.py
@@ -224,22 +224,23 @@ def render_project(
 
         update(f"SCENE_BUILD[{idx}]", 0.2 + (index / max(1, len(scenes))) * 0.6)
         silent_scene = temp_dir / "scene_silent.mp4"
-        concat_inputs: List[str] = []
+        concat_list = temp_dir / "segments.txt"
+        concat_lines = []
         for seg in segment_paths:
-            concat_inputs.extend(["-i", str(seg)])
-
-        concat_filter = "".join(f"[{i}:v]" for i in range(len(segment_paths)))
-        concat_filter += f"concat=n={len(segment_paths)}:v=1:a=0[v]"
+            escaped = str(seg.resolve()).replace("'", "'\\''")
+            concat_lines.append(f"file '{escaped}'")
+        concat_list.write_text("\n".join(concat_lines), encoding="utf-8")
 
         run(
             [
                 "ffmpeg",
                 "-y",
-                *concat_inputs,
-                "-filter_complex",
-                concat_filter,
-                "-map",
-                "[v]",
+                "-f",
+                "concat",
+                "-safe",
+                "0",
+                "-i",
+                str(concat_list),
                 "-c:v",
                 "libx264",
                 "-preset",


### PR DESCRIPTION
## Summary
- switch scene assembly to use the ffmpeg concat demuxer and a temporary segment list
- ensure every image segment is listed explicitly so stitched scenes include all segments

## Testing
- python -m compileall render-api/app

------
https://chatgpt.com/codex/tasks/task_e_68cc78dd1f84832d9a8997d4f671b3a4