### PR TITLE
Improve local storage fallback for local runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ mkdir -p ~/Videos/{logs,projects}
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `RENDER_STORAGE` | `/videos` | Root for shared storage volume inside the containers (bound to `~/Videos`). |
+| `RENDER_STORAGE` | `/videos` | Root for shared storage volume inside the containers. When unset locally the API falls back to `~/Videos` (and then `./videos`) automatically. |
 | `DB_URL` | `sqlite:////videos/db.sqlite3` | SQLAlchemy connection string. |
 | `AUTH_TOKEN` | `change-me` | Bearer token required by all API routes. |
 | `ALLOW_ORIGINS` | `http://localhost:5173` | Comma-delimited origins allowed by CORS. |
@@ -170,9 +170,9 @@ cd rs-video-stitch
 
 If you already have the repo, just `git pull` and `cd` into it.
 
-### 2. Create the storage layout
+### 2. Create the storage layout (optional)
 
-The services expect the same directory hierarchy Docker would mount at `/videos`.
+The services will automatically create `~/Videos` (or `./videos`) the first time they run, but you can pre-create the structure if you prefer:
 
 ```bash
 mkdir -p ~/Videos/{logs,projects}

--- a/render-api/app/db.py
+++ b/render-api/app/db.py
@@ -3,11 +3,37 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
+from pathlib import Path
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
-DB_URL = os.getenv("DB_URL", "sqlite:////videos/db.sqlite3")
+from app.storage import resolve_storage_root
+
+# Mirror the storage layout helpers so local development defaults to the same
+# directory structure Docker uses while still working on developer laptops.
+_storage_root = resolve_storage_root()
+_default_db_url = "sqlite:///" + (_storage_root / "db.sqlite3").as_posix()
+DB_URL = os.getenv("DB_URL", _default_db_url)
+
+
+def _ensure_sqlite_directory(url: str) -> None:
+    try:
+        parsed = make_url(url)
+    except Exception:
+        return
+
+    if parsed.drivername != "sqlite" or not parsed.database or parsed.database == ":memory:":
+        return
+
+    db_path = Path(parsed.database).expanduser()
+    if not db_path.is_absolute():
+        db_path = db_path.resolve()
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+
+
+_ensure_sqlite_directory(DB_URL)
 engine = create_engine(DB_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, future=True, expire_on_commit=False)
 Base = declarative_base()

--- a/render-api/app/storage.py
+++ b/render-api/app/storage.py
@@ -6,7 +6,31 @@ import shutil
 from pathlib import Path
 from typing import Iterable, List
 
-ROOT = Path(os.getenv("RENDER_STORAGE", "/videos"))
+def resolve_storage_root() -> Path:
+    """Return a writable storage root for local or container execution."""
+
+    env_root = os.getenv("RENDER_STORAGE")
+    if env_root:
+        return Path(env_root).expanduser()
+
+    candidates = [
+        Path.home() / "Videos",
+        Path.cwd() / "videos",
+        Path(__file__).resolve().parents[2] / "videos",
+    ]
+
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        return candidate
+
+    # Final fallback if none of the candidates could be created.
+    return candidates[0]
+
+
+ROOT = resolve_storage_root()
 
 
 def proj_root(pid: str) -> Path:

--- a/render-api/app/worker.py
+++ b/render-api/app/worker.py
@@ -2,19 +2,16 @@
 from __future__ import annotations
 
 import datetime as dt
-import os
 import time
 import traceback
-from pathlib import Path
 
 from sqlalchemy import select
 
 from app.db import SessionLocal
 from app.models import Artifact, Job
 from app.renderer import render_project
-from app.storage import job_log_path
+from app.storage import ROOT as STORAGE_ROOT, job_log_path
 
-STORAGE_ROOT = Path(os.getenv("RENDER_STORAGE", "/videos"))
 POLL_INTERVAL = 1.0
 
 


### PR DESCRIPTION
## Summary
- add a shared helper to resolve a writable storage root with local fallbacks when RENDER_STORAGE is unset
- reuse the shared storage root when building the default SQLite URL so virtualenv runs work without manual directories
- document that the services now auto-create the storage layout when running outside Docker

## Testing
- python -m compileall render-api/app

------
https://chatgpt.com/codex/tasks/task_e_68cc8d3cc928832dadd5498521fe7b66