### PR TITLE
Append unique suffix to new project directories

### DIFF
--- a/render-api/app/api.py
+++ b/render-api/app/api.py
@@ -111,9 +111,14 @@ async def upsert_scenes(
     spec: ProjectSpec,
     db: Session = Depends(get_db),
 ) -> dict:
-    ensure_dirs(pid)
+    project_name = None
+    if spec.info and isinstance(spec.info, dict):
+        name_value = spec.info.get("name")
+        if name_value is not None:
+            project_name = str(name_value)
+
     payload = json.dumps(spec.model_dump(mode="json", by_alias=True), indent=2)
-    save_scenes(pid, payload)
+    save_scenes(pid, payload, project_name=project_name)
 
     project = db.get(Project, pid)
     if project is None:

--- a/render-api/app/storage.py
+++ b/render-api/app/storage.py
@@ -1,10 +1,13 @@
 """Helpers for working with the shared storage volume."""
 from __future__ import annotations
 
+import json
 import os
+import re
+import secrets
 import shutil
 from pathlib import Path
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
 def _prepare_storage_dir(path: Path) -> Path | None:
     """Ensure *path* exists and is writable, returning it on success."""
@@ -53,10 +56,95 @@ def resolve_storage_root() -> Path:
     )
 
 ROOT = resolve_storage_root()
+PROJECTS_ROOT = ROOT / "projects"
+META_SUFFIX = ".meta.json"
+
+_slug_pattern = re.compile(r"[^a-z0-9]+")
+
+
+def _project_meta_path(pid: str) -> Path:
+    return PROJECTS_ROOT / f"{pid}{META_SUFFIX}"
+
+
+def _slugify_name(name: str) -> str:
+    slug = _slug_pattern.sub("-", name.lower()).strip("-")
+    return slug or "project"
+
+
+def _load_directory_from_meta(pid: str) -> Optional[Path]:
+    meta_path = _project_meta_path(pid)
+    if not meta_path.exists():
+        return None
+
+    try:
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    directory = data.get("directory")
+    if not directory:
+        return None
+
+    return PROJECTS_ROOT / directory
+
+
+def _directory_reserved(directory: str) -> bool:
+    candidate = PROJECTS_ROOT / directory
+    if candidate.exists():
+        return True
+
+    for meta_file in PROJECTS_ROOT.glob(f"*{META_SUFFIX}"):
+        try:
+            data = json.loads(meta_file.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if data.get("directory") == directory:
+            return True
+    return False
+
+
+def _create_directory_name(pid: str, project_name: Optional[str]) -> Path:
+    base = project_name or pid
+    slug = _slugify_name(base)
+
+    PROJECTS_ROOT.mkdir(parents=True, exist_ok=True)
+
+    for _ in range(10000):
+        suffix = secrets.randbelow(10000)
+        directory = f"{slug}-{suffix:04d}"
+        if not _directory_reserved(directory):
+            meta_path = _project_meta_path(pid)
+            meta_tmp = meta_path.with_suffix(meta_path.suffix + ".tmp")
+            meta_data = {"directory": directory, "slug": slug, "name": project_name}
+            meta_tmp.write_text(json.dumps(meta_data), encoding="utf-8")
+            meta_tmp.replace(meta_path)
+            return PROJECTS_ROOT / directory
+
+    raise RuntimeError("Unable to allocate unique project directory name")
+
+
+def _resolve_project_root(pid: str, project_name: Optional[str] = None) -> Path:
+    existing = _load_directory_from_meta(pid)
+    if existing is not None:
+        return existing
+
+    legacy = PROJECTS_ROOT / pid
+    if legacy.exists():
+        return legacy
+
+    return _create_directory_name(pid, project_name)
 
 
 def proj_root(pid: str) -> Path:
-    return ROOT / "projects" / pid
+    meta = _load_directory_from_meta(pid)
+    if meta is not None:
+        return meta
+
+    legacy = PROJECTS_ROOT / pid
+    if legacy.exists():
+        return legacy
+
+    return legacy
 
 
 def p_input(pid: str) -> Path:
@@ -75,13 +163,15 @@ def logs_dir() -> Path:
     return ROOT / "logs"
 
 
-def ensure_dirs(pid: str) -> None:
-    for directory in (proj_root(pid), p_input(pid), p_work(pid), p_output(pid), logs_dir()):
+def ensure_dirs(pid: str, project_name: Optional[str] = None) -> Path:
+    root = _resolve_project_root(pid, project_name=project_name)
+    for directory in (root, root / "input", root / "work", root / "output", logs_dir()):
         directory.mkdir(parents=True, exist_ok=True)
+    return root
 
 
-def save_scenes(pid: str, content: str) -> Path:
-    ensure_dirs(pid)
+def save_scenes(pid: str, content: str, project_name: Optional[str] = None) -> Path:
+    ensure_dirs(pid, project_name=project_name)
     target = p_input(pid) / "scenes.json"
     target.write_text(content, encoding="utf-8")
     return target


### PR DESCRIPTION
## Summary
- derive the project name from uploaded scene specs and hand it to the storage helpers
- generate project folders under videos/projects with a slug plus a unique 4-digit suffix and persist the mapping via metadata files

## Testing
- python -m compileall render-api/app

------
https://chatgpt.com/codex/tasks/task_e_68ccbfb05780832daf70543525047140